### PR TITLE
[MAINTENANCE][COMPAT_V10]

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -156,8 +156,8 @@ abstract class AbstractController extends ActionController
         $this->persistenceManager->persistAll();
         $this->signalSlotDispatcher->dispatch(__CLASS__, __FUNCTION__ . 'AfterPersist', [$user, $this]);
         LogUtility::log(Log::STATUS_PROFILEUPDATED, $user, ['existingUser' => $existingUser]);
-        $this->redirectByAction('edit');
         $this->addFlashMessage(LocalizationUtility::translate('update'));
+        $this->redirectByAction('edit', 'requestRedirect');
     }
 
     /**
@@ -298,6 +298,9 @@ abstract class AbstractController extends ActionController
             $this->uriBuilder->setLinkAccessRestrictedPages(true);
             $link = $this->uriBuilder->build();
             $this->redirectToUri(StringUtility::removeDoubleSlashesFromUri($link));
+        }
+        if($action === 'edit'){
+            $this->redirect('edit');
         }
         $this->redirect('createStatus');
 

--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -299,6 +299,8 @@ abstract class AbstractController extends ActionController
             $link = $this->uriBuilder->build();
             $this->redirectToUri(StringUtility::removeDoubleSlashesFromUri($link));
         }
+        $this->redirect('createStatus');
+
     }
 
     /**

--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -31,31 +31,31 @@ abstract class AbstractController extends ActionController
 
     /**
      * @var \In2code\Femanager\Domain\Repository\UserRepository
-     * @inject
+     * @TYPO3\CMS\Extbase\Annotation\Inject
      */
     protected $userRepository;
 
     /**
      * @var \In2code\Femanager\Domain\Repository\UserGroupRepository
-     * @inject
+     * @TYPO3\CMS\Extbase\Annotation\Inject
      */
     protected $userGroupRepository;
 
     /**
      * @var \TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager
-     * @inject
+     * @TYPO3\CMS\Extbase\Annotation\Inject
      */
     protected $persistenceManager;
 
     /**
      * @var \In2code\Femanager\Domain\Service\SendMailService
-     * @inject
+     * @TYPO3\CMS\Extbase\Annotation\Inject
      */
     protected $sendMailService;
 
     /**
      * @var \In2code\Femanager\Finisher\FinisherRunner
-     * @inject
+     * @TYPO3\CMS\Extbase\Annotation\Inject
      */
     protected $finisherRunner;
 

--- a/Classes/Controller/EditController.php
+++ b/Classes/Controller/EditController.php
@@ -15,6 +15,8 @@ use In2code\Femanager\Utility\UserUtility;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Exception\UnsupportedRequestTypeException;
+use TYPO3\CMS\Extbase\Annotation as Extbase;
+
 
 /**
  * Class EditController
@@ -58,9 +60,9 @@ class EditController extends AbstractController
 
     /**
      * @param User $user
-     * @validate $user In2code\Femanager\Domain\Validator\ServersideValidator
-     * @validate $user In2code\Femanager\Domain\Validator\PasswordValidator
-     * @validate $user In2code\Femanager\Domain\Validator\CaptchaValidator
+     * @Extbase\Validate("In2code\Femanager\Domain\Validator\ServersideValidator", param="user")
+     * @Extbase\Validate("In2code\Femanager\Domain\Validator\PasswordValidator", param="user")
+     * @Extbase\Validate("In2code\Femanager\Domain\Validator\CaptchaValidator", param="user")
      * @return void
      */
     public function updateAction(User $user)

--- a/Classes/Controller/InvitationController.php
+++ b/Classes/Controller/InvitationController.php
@@ -12,6 +12,7 @@ use In2code\Femanager\Utility\StringUtility;
 use In2code\Femanager\Utility\UserUtility;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Annotation as Extbase;
 
 /**
  * Class InvitationController
@@ -35,9 +36,9 @@ class InvitationController extends AbstractController
      * action create
      *
      * @param User $user
-     * @validate $user In2code\Femanager\Domain\Validator\ServersideValidator
-     * @validate $user In2code\Femanager\Domain\Validator\PasswordValidator
-     * @validate $user In2code\Femanager\Domain\Validator\CaptchaValidator
+     * @Extbase\Validate("In2code\Femanager\Domain\Validator\ServersideValidator", param="user")
+     * @Extbase\Validate("In2code\Femanager\Domain\Validator\PasswordValidator", param="user")
+     * @Extbase\Validate("In2code\Femanager\Domain\Validator\CaptchaValidator", param="user")
      * @return void
      */
     public function createAction(User $user)
@@ -144,8 +145,8 @@ class InvitationController extends AbstractController
      * action update
      *
      * @param \In2code\Femanager\Domain\Model\User $user
-     * @validate $user In2code\Femanager\Domain\Validator\ServersideValidator
-     * @validate $user In2code\Femanager\Domain\Validator\PasswordValidator
+     * @Extbase\Validate("In2code\Femanager\Domain\Validator\ServersideValidator", param="user")
+     * @Extbase\Validate("In2code\Femanager\Domain\Validator\PasswordValidator", param="user")
      * @return void
      */
     public function updateAction($user)

--- a/Classes/Controller/NewController.php
+++ b/Classes/Controller/NewController.php
@@ -17,6 +17,7 @@ use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Exception\UnsupportedRequestTypeException;
 use TYPO3\CMS\Extbase\Persistence\Exception\IllegalObjectTypeException;
+use TYPO3\CMS\Extbase\Annotation as Extbase;
 
 /**
  * Class NewController
@@ -45,9 +46,9 @@ class NewController extends AbstractController
      * action create
      *
      * @param User $user
-     * @validate $user In2code\Femanager\Domain\Validator\ServersideValidator
-     * @validate $user In2code\Femanager\Domain\Validator\PasswordValidator
-     * @validate $user In2code\Femanager\Domain\Validator\CaptchaValidator
+     * @Extbase\Validate("In2code\Femanager\Domain\Validator\ServersideValidator", param="user")
+     * @Extbase\Validate("In2code\Femanager\Domain\Validator\PasswordValidator", param="user")
+     * @Extbase\Validate("In2code\Femanager\Domain\Validator\CaptchaValidator", param="user")
      * @return void
      */
     public function createAction(User $user)

--- a/Classes/Domain/Repository/PluginRepository.php
+++ b/Classes/Domain/Repository/PluginRepository.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 namespace In2code\Femanager\Domain\Repository;
 
 use In2code\Femanager\Utility\ObjectUtility;
-use TYPO3\CMS\Extbase\Service\FlexFormService;
+use TYPO3\CMS\Core\Service\FlexFormService;
 
 /**
  * Class PluginRepository

--- a/Classes/Domain/Service/FinisherService.php
+++ b/Classes/Domain/Service/FinisherService.php
@@ -63,7 +63,7 @@ class FinisherService
 
     /**
      * @var \TYPO3\CMS\Extbase\Object\ObjectManagerInterface
-     * @inject
+     * @TYPO3\CMS\Extbase\Annotation\Inject
      */
     protected $objectManager = null;
 

--- a/Classes/Domain/Service/SendMailService.php
+++ b/Classes/Domain/Service/SendMailService.php
@@ -26,7 +26,7 @@ class SendMailService
      * SignalSlot Dispatcher
      *
      * @var \TYPO3\CMS\Extbase\SignalSlot\Dispatcher
-     * @inject
+     * @TYPO3\CMS\Extbase\Annotation\Inject
      */
     protected $signalSlotDispatcher;
 
@@ -147,8 +147,7 @@ class SendMailService
             ->setTo($receiver)
             ->setFrom($sender)
             ->setSubject($subject)
-            ->setCharset(FrontendUtility::getCharset())
-            ->setBody($this->getMailBody($template, $variables), 'text/html');
+            ->html($this->getMailBody($template, $variables), 'text/html');
     }
 
     /**

--- a/Classes/Domain/Service/SendParametersService.php
+++ b/Classes/Domain/Service/SendParametersService.php
@@ -14,7 +14,7 @@ class SendParametersService
 
     /**
      * @var \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface
-     * @inject
+     * @TYPO3\CMS\Extbase\Annotation\Inject
      */
     protected $configurationManager;
 

--- a/Classes/Domain/Validator/AbstractValidator.php
+++ b/Classes/Domain/Validator/AbstractValidator.php
@@ -21,7 +21,7 @@ abstract class AbstractValidator extends AbstractValidatorExtbase
      * userRepository
      *
      * @var \In2code\Femanager\Domain\Repository\UserRepository
-     * @inject
+     * @TYPO3\CMS\Extbase\Annotation\Inject
      */
     protected $userRepository;
 
@@ -29,7 +29,7 @@ abstract class AbstractValidator extends AbstractValidatorExtbase
      * configurationManager
      *
      * @var \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface
-     * @inject
+     * @TYPO3\CMS\Extbase\Annotation\Inject
      */
     public $configurationManager;
 

--- a/Classes/Domain/Validator/PasswordValidator.php
+++ b/Classes/Domain/Validator/PasswordValidator.php
@@ -16,7 +16,7 @@ class PasswordValidator extends AbstractValidatorExtbase
      * configurationManager
      *
      * @var \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface
-     * @inject
+     * @TYPO3\CMS\Extbase\Annotation\Inject
      */
     public $configurationManager;
 

--- a/Classes/Finisher/FinisherRunner.php
+++ b/Classes/Finisher/FinisherRunner.php
@@ -14,13 +14,13 @@ class FinisherRunner
 
     /**
      * @var \TYPO3\CMS\Extbase\Object\ObjectManagerInterface
-     * @inject
+     * @TYPO3\CMS\Extbase\Annotation\Inject
      */
     protected $objectManager;
 
     /**
      * @var \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface
-     * @inject
+     * @TYPO3\CMS\Extbase\Annotation\Inject
      */
     protected $configurationManager;
 

--- a/Classes/Finisher/SaveToAnyTableFinisher.php
+++ b/Classes/Finisher/SaveToAnyTableFinisher.php
@@ -15,19 +15,19 @@ class SaveToAnyTableFinisher extends AbstractFinisher implements FinisherInterfa
      * Inject a complete new content object
      *
      * @var \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer
-     * @inject
+     * @TYPO3\CMS\Extbase\Annotation\Inject
      */
     protected $contentObject;
 
     /**
      * @var \TYPO3\CMS\Extbase\Object\ObjectManager
-     * @inject
+     * @TYPO3\CMS\Extbase\Annotation\Inject
      */
     protected $objectManager;
 
     /**
-     * @var \TYPO3\CMS\Extbase\Service\TypoScriptService
-     * @inject
+     * @var \TYPO3\CMS\Core\TypoScript\TypoScriptService
+     * @TYPO3\CMS\Extbase\Annotation\Inject
      */
     protected $typoScriptService;
 

--- a/Classes/Finisher/SendParametersFinisher.php
+++ b/Classes/Finisher/SendParametersFinisher.php
@@ -15,13 +15,13 @@ class SendParametersFinisher extends AbstractFinisher implements FinisherInterfa
      * Inject a complete new content object
      *
      * @var \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer
-     * @inject
+     * @TYPO3\CMS\Extbase\Annotation\Inject
      */
     protected $contentObject;
 
     /**
      * @var \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface
-     * @inject
+     * @TYPO3\CMS\Extbase\Annotation\Inject
      */
     protected $configurationManager;
 

--- a/Classes/ViewHelpers/Be/GetClassNameOnActionViewHelper.php
+++ b/Classes/ViewHelpers/Be/GetClassNameOnActionViewHelper.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace In2code\Femanager\ViewHelpers\Be;
 
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Class GetClassNameOnActionViewHelper

--- a/Classes/ViewHelpers/Be/IsConfirmationModuleActivatedViewHelper.php
+++ b/Classes/ViewHelpers/Be/IsConfirmationModuleActivatedViewHelper.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 namespace In2code\Femanager\ViewHelpers\Be;
 
 use In2code\Femanager\Utility\ConfigurationUtility;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Class IsConfirmationModuleActivatedViewHelper

--- a/Classes/ViewHelpers/Be/IsResendUserConfirmationRequestActivatedViewHelper.php
+++ b/Classes/ViewHelpers/Be/IsResendUserConfirmationRequestActivatedViewHelper.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 namespace In2code\Femanager\ViewHelpers\Be;
 
 use In2code\Femanager\Utility\ConfigurationUtility;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Class IsConfirmationModuleActivatedViewHelper

--- a/Classes/ViewHelpers/Condition/IsBackendAdministratorAuthenticationViewHelper.php
+++ b/Classes/ViewHelpers/Condition/IsBackendAdministratorAuthenticationViewHelper.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 namespace In2code\Femanager\ViewHelpers\Condition;
 
 use In2code\Femanager\Utility\BackendUserUtility;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Class IsBackendAdministratorAuthenticationViewHelper

--- a/Classes/ViewHelpers/Form/GetCountriesFromStaticInfoTablesViewHelper.php
+++ b/Classes/ViewHelpers/Form/GetCountriesFromStaticInfoTablesViewHelper.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace In2code\Femanager\ViewHelpers\Form;
 
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Class GetCountriesFromStaticInfoTablesViewHelper
@@ -16,7 +16,7 @@ class GetCountriesFromStaticInfoTablesViewHelper extends AbstractViewHelper
      * countryRepository
      *
      * @var \SJBR\StaticInfoTables\Domain\Repository\CountryRepository
-     * @inject
+     * @TYPO3\CMS\Extbase\Annotation\Inject
      */
     protected $countryRepository;
 

--- a/Classes/ViewHelpers/Form/GetCountriesViewHelper.php
+++ b/Classes/ViewHelpers/Form/GetCountriesViewHelper.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace In2code\Femanager\ViewHelpers\Form;
 
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Class GetCountriesViewHelper

--- a/Classes/ViewHelpers/Misc/CaptchaEnabledViewHelper.php
+++ b/Classes/ViewHelpers/Misc/CaptchaEnabledViewHelper.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 namespace In2code\Femanager\ViewHelpers\Misc;
 
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Look if captcha is enabled

--- a/Classes/ViewHelpers/Misc/ExplodeViewHelper.php
+++ b/Classes/ViewHelpers/Misc/ExplodeViewHelper.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace In2code\Femanager\ViewHelpers\Misc;
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Class ExplodeViewHelper

--- a/Classes/ViewHelpers/Misc/JsonEncodeViewHelper.php
+++ b/Classes/ViewHelpers/Misc/JsonEncodeViewHelper.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace In2code\Femanager\ViewHelpers\Misc;
 
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Class JsonEncodeViewHelper

--- a/Classes/ViewHelpers/Misc/RequestViewHelper.php
+++ b/Classes/ViewHelpers/Misc/RequestViewHelper.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace In2code\Femanager\ViewHelpers\Misc;
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Class RequestViewHelper

--- a/Classes/ViewHelpers/Misc/UpperViewHelper.php
+++ b/Classes/ViewHelpers/Misc/UpperViewHelper.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace In2code\Femanager\ViewHelpers\Misc;
 
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Class UpperViewHelper

--- a/Classes/ViewHelpers/Repository/GetFirstViewHelper.php
+++ b/Classes/ViewHelpers/Repository/GetFirstViewHelper.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace In2code\Femanager\ViewHelpers\Repository;
 
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Class GetFirstViewHelper

--- a/Classes/ViewHelpers/Validation/FormValidationDataViewHelper.php
+++ b/Classes/ViewHelpers/Validation/FormValidationDataViewHelper.php
@@ -24,9 +24,7 @@ class FormValidationDataViewHelper extends AbstractValidationViewHelper
         $additionalAttributes = $this->arguments['additionalAttributes'];
 
         if ($settings !== []) {
-            GeneralUtility::deprecationLog(
-                'Settings should not be filled any more in field partials. Pls update your femanager partial files.'
-            );
+            trigger_error('Settings should not be filled any more in field partials. Pls update your femanager partial files.', E_USER_DEPRECATED);
         }
         $validationService = ObjectUtility::getObjectManager()->get(
             ValidationSettingsService::class,

--- a/Classes/ViewHelpers/Validation/IsRequiredFieldViewHelper.php
+++ b/Classes/ViewHelpers/Validation/IsRequiredFieldViewHelper.php
@@ -13,7 +13,7 @@ class IsRequiredFieldViewHelper extends AbstractValidationViewHelper
 
     /**
      * @var \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface
-     * @inject
+     * @TYPO3\CMS\Extbase\Annotation\Inject
      */
     protected $configurationManager;
 

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types = 1);
+
+return [
+    \In2code\Femanager\Domain\Model\User::class => [
+        'tableName' => 'fe_users',
+        'properties' => [
+            'terms' => [
+                'fieldName' => 'tx_femanager_terms',
+            ],
+            'termsDateOfAcceptance' => [
+                'fieldName' => 'tx_femanager_terms_date_of_acceptance',
+            ],
+        ],
+    ],
+    \In2code\Femanager\Domain\Model\UserGroup::class => [
+        'tableName' => 'fe_groups',
+    ],
+];

--- a/Configuration/TCA/tx_femanager_domain_model_log.php
+++ b/Configuration/TCA/tx_femanager_domain_model_log.php
@@ -26,7 +26,6 @@ return [
         'iconfile' => 'EXT:femanager/Resources/Public/Icons/Log.png'
     ],
     'interface' => [
-        'showRecordFieldList' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, title, crdate, state, user',
     ],
     'types' => [
         '1' => [
@@ -55,7 +54,6 @@ return [
         ],
         'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
-            'exclude' => 1,
             'label' => 'LLL:EXT:lang/locallang_general.xlf:LGL.l18n_parent',
             'config' => [
                 'type' => 'select',

--- a/Configuration/TypoScript/Main/setup.txt
+++ b/Configuration/TypoScript/Main/setup.txt
@@ -1647,13 +1647,13 @@ plugin.tx_femanager {
 # Inlude JavaScript files
 #########################
 # add jQuery if it was turned on in the constants
-[globalVar = LIT:0 < {$plugin.tx_femanager.settings.jQuery}]
+[{$plugin.tx_femanager.settings.jQuery} == '1']
 page.includeJSFooterlibs.femanagerJQuery = //ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js
 page.includeJSFooterlibs.femanagerJQuery.external = 1
 [end]
 
 # add twitter bootstrap JS if it was turned on in the constants
-[globalVar = LIT:0 < {$plugin.tx_femanager.settings.bootstrap}]
+[{$plugin.tx_femanager.settings.bootstrap} == '1']
 page.includeJSFooterlibs.femanangerBootstrap = //maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js
 page.includeJSFooterlibs.femanangerBootstrap.external = 1
 [end]
@@ -1662,7 +1662,7 @@ page.includeJSFooterlibs.femanangerBootstrap.external = 1
 # Inlude CSS files
 #########################
 # add twitter bootstrap CSS if it was turned on in the constants
-[globalVar = LIT:0 < {$plugin.tx_femanager.settings.bootstrapCSS}]
+[{$plugin.tx_femanager.settings.bootstrapCSS} == '1']
 page.includeCSS.femanangerBootstrap = //maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css
 page.includeCSS.femanangerBootstrap.external = 1
 [end]

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -2128,13 +2128,13 @@ Plain Text
     # Inlude JavaScript files
     #########################
     # add jQuery if it was turned on in the constants
-    [globalVar = LIT:0 < {$plugin.tx_femanager.settings.jQuery}]
+    [{$plugin.tx_femanager.settings.jQuery} == '1']
     page.includeJSFooterlibs.femanagerJQuery = //ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js
     page.includeJSFooterlibs.femanagerJQuery.external = 1
     [end]
 
     # add twitter bootstrap JS if it was turned on in the constants
-    [globalVar = LIT:0 < {$plugin.tx_femanager.settings.bootstrap}]
+    [{$plugin.tx_femanager.settings.bootstrap} == '1']
     page.includeJSFooterlibs.femanangerBootstrap = //maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js
     page.includeJSFooterlibs.femanangerBootstrap.external = 1
     [end]
@@ -2143,7 +2143,7 @@ Plain Text
     # Inlude CSS files
     #########################
     # add twitter bootstrap CSS if it was turned on in the constants
-    [globalVar = LIT:0 < {$plugin.tx_femanager.settings.bootstrapCSS}]
+    [{$plugin.tx_femanager.settings.bootstrapCSS} == '1']
     page.includeCSS.femanangerBootstrap = //maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css
     page.includeCSS.femanangerBootstrap.external = 1
     [end]

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   "type": "typo3-cms-extension",
   "license": "GPL-2.0-or-later",
   "require": {
-    "typo3/cms-core": ">=8.7.0 <9.6.0"
+    "typo3/cms-core": ">=8.7.0 || <9.6.0 || ^10"
   },
   "replace": {
     "femanager": "self.version",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -26,7 +26,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '5.2.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '8.7.0-9.5.99',
+            'typo3' => '8.7.0--10.4.99',
             'php' => '7.0.0-7.3.99',
         ],
         'conflicts' => [],


### PR DESCRIPTION
- adjusted typo3 version constraints in composer.json and ext_emconf.php files
- refactored annotations: @validate
- refactored annotations: @inject
- refactored namespace of FlexFormService (from EXT:extbase to EXT:core)
- refactored namespace of TypoScriptService (from EXT:extbase to EXT:core)
- refactored namespace of AbstractViewHelper (from EXT:fluid to EXT:core)
- refactored GeneralUtility::deprecationLog: use trigger_error instead
- refactored TCA
    - removed showRecordFieldList
    - removed exclude = true/1 for l10n_parent column
- refactored all typoscript conditions: migrated to Symfony Expression Language
- adjusted typoscript conditions in documentation file
- refactored SendMailService: removed charset, added text() instead of setBody()
- refactored persistence class mapping: migrated to Configuration/Extbase/Persistence/Classes.php